### PR TITLE
Fix division precision behavior

### DIFF
--- a/TP3---LOG3000-main/operators.py
+++ b/TP3---LOG3000-main/operators.py
@@ -46,4 +46,4 @@ def divide(a,b):
     Returns:
         Numeric division result.
     """
-    return a // b
+    return a / b


### PR DESCRIPTION
## Summary
- Replace floor division with true division in `divide`
- Ensure decimal precision is preserved for non-integer quotients

## Test plan
- [x] Run `pytest -q tests/test_operators.py -k divide_returns_true_division`
- [x] Confirm division precision test passes on this branch

Closes #4